### PR TITLE
Fix unclosed HTML element issue

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -146,6 +146,7 @@ You can use this `[addonify_wishlist]` shortcode to display the wishlist table i
 - Removed: Added to cart popup modal displayed when product is added to cart in wishlist page.
 - Tweak: Popup modal now closes when clicked on modal overlay.
 - Fix: Issue of product stock status not getting displaying in wishlist sidebar when a product is added into the wishlist. [GitHub Issue #344](https://github.com/addonify/addonify-wishlist/issues/344)
+- Fix: Unclosed HTML element caused by improperly defined attribute `data-wishlist_id` of add to wishlist button. [GitHub Issue #348](https://github.com/addonify/addonify-wishlist/issues/348)
 
 = 2.0.1 - 15 May, 2023 =
 

--- a/public/class-addonify-wishlist-public.php
+++ b/public/class-addonify-wishlist-public.php
@@ -572,7 +572,7 @@ class Addonify_Wishlist_Public {
 
 		if (
 			addonify_wishlist_get_option( 'btn_position_on_single' ) === 'before_add_to_cart_form' ||
-			addonify_wishlist_get_option( 'btn_position_on_single' ) === 'adter_add_to_cart_form'
+			addonify_wishlist_get_option( 'btn_position_on_single' ) === 'after_add_to_cart_form'
 		) {
 			echo '</div>';
 		}

--- a/public/templates/addonify-add-to-wishlist-button.php
+++ b/public/templates/addonify-add-to-wishlist-button.php
@@ -26,7 +26,7 @@ if ( $display_icon ) {
 $wishlist               = '';
 $button_label_preserved = '';
 if ( isset( $parent_wishlist_id ) ) {
-	$wishlist = 'data-wishlist_id=' . $parent_wishlist_id;
+	$wishlist = 'data-wishlist_id="' . $parent_wishlist_id . '"';
 } else {
 	$parent_wishlist_id = '';
 }


### PR DESCRIPTION
- Fix: Unclosed HTML element caused by improperly defined attribute `data-wishlist_id` of add to wishlist button. [GitHub Issue #348](https://github.com/addonify/addonify-wishlist/issues/348)