### PR TITLE
Support for pro version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -140,6 +140,11 @@ You can use this `[addonify_wishlist]` shortcode to display the wishlist table i
 
 == Changelog ==
 
+= 2.0.6 - ? July, 2023 =
+
+- Updated: Action hooks `addonify_wishlist_before_adding_to_wishlist` and `addonify_wishlist_after_adding_to_wishlist`. Array argument is passed in both action hooks.
+
+
 = 2.0.5 - 29 June, 2023 =
 
 - Fix: Invalid JSON body passed while importing options.

--- a/includes/class-adfy-wishlist.php
+++ b/includes/class-adfy-wishlist.php
@@ -138,27 +138,34 @@ class Adfy_Wishlist {
 
 		$return_boolean = false;
 
-		do_action( 'addonify_wishlist_before_adding_to_wishlist' );
-
 		if ( is_user_logged_in() ) {
 			if ( array_key_exists( (int) $wishlist_id, $this->wishlist_items ) ) {
-				$save['user_id']            = get_current_user_id();
-				$save['site_url']           = get_bloginfo( 'url' );
+
+				$current_user_id = get_current_user_id();
+				$site_url        = get_site_url();
+
+				$save = array();
+
+				$save['user_id']            = $current_user_id;
+				$save['site_url']           = $site_url;
 				$save['parent_wishlist_id'] = $wishlist_id;
 				$save['product_id']         = (int) $product_id;
 
+				do_action( 'addonify_wishlist_before_adding_to_wishlist', $save );
+
 				$insert_id = $this->wishlist->insert_row( $save );
 				if ( $insert_id ) {
+
 					$this->wishlist_items[ $wishlist_id ]['product_ids'][] = (int) $product_id;
 
 					$return_boolean = true;
 				}
+
+				do_action( 'addonify_wishlist_after_adding_to_wishlist', $save );
 			}
 		}
 
 		$this->wishlist_items_count = $this->get_wishlist_count();
-
-		do_action( 'addonify_wishlist_after_adding_to_wishlist' );
 
 		return $return_boolean;
 	}

--- a/public/class-addonify-wishlist-public.php
+++ b/public/class-addonify-wishlist-public.php
@@ -1399,6 +1399,11 @@ class Addonify_Wishlist_Public {
 		}
 	}
 
+	/**
+	 * Gets template for already in wishlist modal content.
+	 *
+	 * @since 2.0.6
+	 */
 	public function already_in_wishlist_template() {
 		ob_start();
 		do_action( 'addonify_wishlist_already_in_wishlist_modal_content' );


### PR DESCRIPTION
- Updated: Action hooks `addonify_wishlist_before_adding_to_wishlist` and `addonify_wishlist_after_adding_to_wishlist`. Array argument is passed in both action hooks.