### PR TITLE
🐛 fix: broken access check. 

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@
 Contributors: addonify
 Tags: wishlist, woocommerce wishlist, product wishlist, add to wishlist, save for later
 Requires at least: 6.3
-Tested up to: 6.8
-Stable tag: 2.0.15
+Tested up to: 6.9.1
+Stable tag: 2.0.16
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -148,6 +148,10 @@ Yes, there is. Use `[addonify_wishlist_button]` shortocde to display wishlist bu
 9. Save for later (Add to wishlist) button in cart page.
 
 == Changelog ==
+
+= 2.0.16 - 15 February, 2026 =
+
+- Fix: Broken Access Control in UDP Agent (CVSS 5.3). Credits to Legion Hunter. Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook due to missing authorization and nonce check in it's callback function "on_init".
 
 = 2.0.15 - 31 March, 2025 =
 

--- a/addonify-wishlist.php
+++ b/addonify-wishlist.php
@@ -10,9 +10,9 @@
  * Plugin Name:       Addonify - WooCommerce Wishlist
  * Plugin URI:        https://wordpress.org/plugins/addonify-wishlist
  * Description:       Addonify WooCommerce Wishlist is a light-weight yet powerful tool that adds a wishlist functionality to your e-commerce shop.
- * Version:           2.0.15
+ * Version:           2.0.16
  * Requires at least: 6.3
- * Tested up to:      6.8
+ * Tested up to:      6.9.1
  * Requires PHP:      7.4
  * Author:            Addonify
  * Author URI:        https://www.addonify.com
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'ADDONIFY_WISHLIST_VERSION', '2.0.15' );
+define( 'ADDONIFY_WISHLIST_VERSION', '2.0.16' );
 define( 'ADDONIFY_WISHLIST_DB_INITIALS', 'addonify_wishlist_' );
 define( 'ADDONIFY_WISHLIST_PLUGIN_PATH', __DIR__ );
 define( 'ADDONIFY_WISHLIST_PLUGIN_FILE', __FILE__ );

--- a/includes/udp/class-udp-agent.php
+++ b/includes/udp/class-udp-agent.php
@@ -177,6 +177,11 @@ class Udp_Agent {
 	 * @since    1.0.0
 	 */
 	private function process_user_tracking_choice() {
+		// Verify if the user is logged in and has the capability to manage options.
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+			wp_safe_redirect( home_url() );
+			exit;
+		}
 
 		$users_choice = isset( $_GET['udp-agent-allow-access'] ) ? sanitize_text_field( wp_unslash( $_GET['udp-agent-allow-access'] ) ) : ''; //phpcs:ignore
 


### PR DESCRIPTION
Fix: Broken Access Control in UDP Agent (CVSS 5.3). Credits to Legion Hunter. Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook due to missing authorization and nonce check in it's callback function "on_init".